### PR TITLE
Updated README.mde with National Statistics Postcode Lookup UK

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
   * [Shops](http://open.datapunt.amsterdam.nl/Shoppen.json)
   * [Food and Drinks](http://open.datapunt.amsterdam.nl/EtenDrinken.json)
   * [Museums and Galleries](http://open.datapunt.amsterdam.nl/MuseaGalleries.json)
+* UK
+  * [National Statistics Postcode Lookup UK](https://opendata.camden.gov.uk/api/views/tr8t-gqz7/rows.json?accessType=DOWNLOAD)
 
 ## Historical Events
 * Languages


### PR DESCRIPTION
National Statistics Postcode Lookup UK 

This dataset contains the National Statistics Postcode Lookup (NSPL) for the United Kingdom. The NSPL relates current postcodes to a range of current statutory administrative, electoral, health and other statistical geographies via ‘best-fit’ allocation from the 2011 Census output areas. It supports the production of area based statistics from postcoded data. The NSPL is produced by ONS Geography, which provides geographic support to the Office for National Statistics (ONS) and geographic services used by other organisations.
